### PR TITLE
QDR-901 - handle URLs with ;

### DIFF
--- a/src/main/webapp/resources/js/shib/isPassive.js
+++ b/src/main/webapp/resources/js/shib/isPassive.js
@@ -43,13 +43,16 @@ if(document.cookie && document.cookie.search(/_check_is_passive_dv=/) >= 0){
         var cookieStr = document.cookie + ";";
         var startpos = (cookieStr.indexOf('_check_is_passive_dv=')+21);
         var endpos = cookieStr.indexOf(';', startpos);
-        window.location = cookieStr.substring(startpos,endpos);
+        //QDR-901 URLs can have a ; char (we see this with a ;jsessionid=... appended to URLs before the query string)
+        // so we must encode and then decode the URL in the cookie to parse correctly (indexOf(';'... in the line above)
+        window.location = decodeURIComponent(cookieStr.substring(startpos,endpos));
     }
 } else {
     // Mark browser as being isPassive checked
 	//QDR Custom - add a domain shared by drupal and dv components
 	//QDR-901 - set cookie path to / (should really be dataverse root) to make sure passive login check only happens once, even when initial page is at a path (e.g. /dataverse/main)
-    document.cookie = "_check_is_passive_dv=" + window.location + ";path=/;domain=" + window.location.hostname.substring(window.location.hostname.indexOf("."));;
+	//QDR-901 - encode URI in cookie
+    document.cookie = "_check_is_passive_dv=" + encodeURIComponent(window.location.href) + ";path=/;domain=" + window.location.hostname.substring(window.location.hostname.indexOf("."));;
 
     // Redirect to Shibboleth handler
     //QDR-901 - include query in redirect to avoid changing result after passive check


### PR DESCRIPTION
; is not an allowed char in cookie values,
but we see it in urls on beta - where a ;jsessionid=... is being
inserted between the path and query. encoding and decoding going in/out
of the cookie handles it. (before this fix, our parsing assumed the
cookie value stopped at the end of the path (seeing the ; in front of
jsessionid), giving the same symptom as not sending the query part at
all...)

## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #ISSUE_NUMBER: ISSUE_TITLE

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/4.6.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
