### PR TITLE
QDR-897 - update builtin password

### DIFF
--- a/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/PasswordEncryption.java
+++ b/src/main/java/edu/harvard/iq/dataverse/authorization/providers/builtin/PasswordEncryption.java
@@ -25,6 +25,14 @@ public final class PasswordEncryption implements java.io.Serializable {
         String encrypt( String plainText );
         boolean check( String plainText, String hashed );
     }
+    /**
+     * Main method - QDR Custom: allow password generation, using latest algorithm, from the command line
+     */
+    
+    public static void main(String[] args) {
+    	String ep = PasswordEncryption.get().encrypt(args[0]);
+    	System.out.println(ep);
+    }
     
     /**
      * The SHA algorithm, now considered not secure enough.


### PR DESCRIPTION
With the account page turned off for QDR, it's useful to have a command
line mechanism to generate a new builtin password (e.g. for the
dataverseAdmin user). This change just adds a simple main() method to
the PasswordEncryption class to allow this:

From the top dir of a deployed instance of the war:
java -cp .\WEB-INF\classes;.\WEB-INF\lib\*
edu.harvard.iq.dataverse.authorization.providers.builtin.PasswordEncryption<password>

Output is the encryptedpassword to add to the database:
psql:
\c dvndb
update builtinuser set encryptedpassword=<enc-pass. where
email=<account-email>;

## New Contributors

Welcome! New contributors should at least glance at [CONTRIBUTING.md](/CONTRIBUTING.md), especially the section on pull requests where we encourage you to reach out to other developers before you start coding. Also, please note that we measure code coverage and prefer you write unit tests. Pull requests can still be reviewed without tests or completion of the checklist outlined below. Thanks!

## Related Issues

- connects to #ISSUE_NUMBER: ISSUE_TITLE

## Pull Request Checklist

- [ ] Unit [tests][] completed
- [ ] Integration [tests][]: None
- [ ] Deployment requirements, [SQL updates][], [Solr updates][], etc.: None
- [ ] [Documentation][docs] completed
- [ ] Merged latest from "develop" [branch][] and resolved conflicts

[tests]: http://guides.dataverse.org/en/latest/developers/testing.html
[SQL updates]: https://github.com/IQSS/dataverse/tree/develop/scripts/database/upgrades
[Solr updates]: https://github.com/IQSS/dataverse/blob/develop/conf/solr/4.6.0/schema.xml
[docs]: http://guides.dataverse.org/en/latest/developers/documentation.html
[branch]: http://guides.dataverse.org/en/latest/developers/branching-strategy.html
