### PR TITLE
IQSS/7956 show original file format - minor tweaks

### DIFF
--- a/doc/release-notes/7956-display original file name
+++ b/doc/release-notes/7956-display original file name
@@ -1,2 +1,0 @@
-This release changes the display behavior for tabular files to show the original file name and metadata, and to allow editing of the original file name. The ingested *.tab version is still available from the download menu.
- 

--- a/doc/release-notes/7956-show_original_file_format.md
+++ b/doc/release-notes/7956-show_original_file_format.md
@@ -1,0 +1,2 @@
+This release changes the display behavior of the file, dataset and collection ("dataverse") pages for tabular files. They will show the original file name and information, and will allow editing of the original file name. The ingested *.tab version is still available from the download menu. 
+ 

--- a/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
+++ b/src/main/java/edu/harvard/iq/dataverse/search/IndexServiceBean.java
@@ -1611,7 +1611,7 @@ public class IndexServiceBean {
 
                     String filenameCompleteFinal = "";
                     if (fileMetadata != null) {
-                        String filenameComplete = fileMetadata.getLabel();
+                        String filenameComplete = fileMetadata.getLabelForOriginal();
                         if (filenameComplete != null) {
                             String filenameWithoutExtension = "";
                             // String extension = "";

--- a/src/main/webapp/file.xhtml
+++ b/src/main/webapp/file.xhtml
@@ -15,7 +15,7 @@
 
     <h:body>
         <ui:composition template="/dataverse_template.xhtml">
-            <ui:param name="pageTitle" value="#{FilePage.fileMetadata.dataFile.displayName} - #{FilePage.file.owner.owner.displayName}"/>
+            <ui:param name="pageTitle" value="#{FilePage.fileMetadata.labelForOriginal} - #{FilePage.file.owner.owner.displayName}"/>
             <ui:param name="dataverse" value="#{FilePage.file.owner.owner}"/>
             <ui:param name="showDataverseHeader" value="#{!FilePage.isAnonymizedAccess()}"/>
             <ui:param name="showMessagePanel" value="#{true}"/>

--- a/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
+++ b/src/test/java/edu/harvard/iq/dataverse/api/SearchIT.java
@@ -2220,7 +2220,7 @@ public class SearchIT {
         search.prettyPrint();
         search.then().assertThat()
                 .statusCode(OK.getStatusCode())
-                .body("data.items[0].name", is("data.tab"))
+                .body("data.items[0].name", is("data.csv")) // as of 6.11, we are indexing the original names of ingested tab. files
                 .body("data.items[0].variables", is(4))
                 .body("data.items[0].observations", is(3));
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the file page show the orig. name in the tab title as well; makes Dataverse use the orig. name for indexing in Solr. 

**Which issue(s) this PR closes**:

**Special notes for your reviewer**:

**Suggestions on how to test this**:

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
